### PR TITLE
Override the profile draft document

### DIFF
--- a/src/sanityPluginNavExtend.js
+++ b/src/sanityPluginNavExtend.js
@@ -164,7 +164,7 @@ function useProfileContextValue({ defaultValue, options, profileKey, clientConfi
 
     try {
       await client.createOrReplace({
-        _id: `profile${currentUser.id}`,
+        _id: `drafts.profile${currentUser.id}`,
         _type: 'profile',
         [profileKey]: value
       })


### PR DESCRIPTION
Because updating a published profile does not work because on newer projects. A profile document has never been published before and using this plugin there is no option to publish a profile. You always work with a draft. 

At first i thought using the [Publish action](https://www.sanity.io/docs/js-client#publish-action), but this returns me a error.