### PR TITLE
Fix large list of context items in navbar

### DIFF
--- a/src/sanityPluginNavExtend.js
+++ b/src/sanityPluginNavExtend.js
@@ -98,7 +98,7 @@ function ContextSwitch({ defaultValue, options, profileKey, clientConfig, report
     <ToastProvider>
       <MenuButton
         id='menu-button-context-switch'
-        popover={{ portal: true }}
+        popover={{ portal: true, animate: true, overflow: 'auto', preventOverflow: false }}
         button={<Button
           mode='bleed'
           tone='default'
@@ -108,17 +108,24 @@ function ContextSwitch({ defaultValue, options, profileKey, clientConfig, report
           aria-label='Switch profile context'
         />}
         menu={(
-          <Menu>
-            {options.map(({ id, label, icon }) => (
-              <MenuItem
-                key={`ContextSwitch-item__${id}`}
-                type='button'
-                text={label}
-                selected={profileContextValue === id}
-                onClick={() => setProfileContextValue({ value: id })}
-                {...{ icon }}
-              />
-            ))}
+          <Menu style={{ maxHeight: '80svh' }}>
+            {options.map(({ id, label, icon }) => {
+              const isActive = profileContextValue === id
+
+              return (
+                <MenuItem
+                  key={`ContextSwitch-item__${id}`}
+                  type='button'
+                  paddingX={3}
+                  paddingY={2}
+                  text={label}
+                  selected={isActive}
+                  disabled={isActive}
+                  onClick={() => setProfileContextValue({ value: id })}
+                  {...{ icon }}
+                />
+              )
+            })}
           </Menu>
         )}
       />


### PR DESCRIPTION
Bij een lange lijst werd het menu een beetje problematisch icm kleinere schermen. Dingen die ik heb gewijzigd:
- Popover krijgt nu een overflow en blijft op zijn positie staan
- Het menu heeft nu een maxHeight van 80% van de viewport. Wanneer de lijst langer is zie je een scrollbar
- Het actieve item heeft een `disabled` state gekregen. 
- De padding tussen de items is iets kleiner gemaakt. Standaard is dit `3` en is aangepast naar `2`.

<img width="482" alt="image" src="https://github.com/user-attachments/assets/76628328-04f6-4999-9025-aafaba4e49f6">
